### PR TITLE
change to boolean value

### DIFF
--- a/nao_audio/nodes/nao_audio.py
+++ b/nao_audio/nodes/nao_audio.py
@@ -120,7 +120,7 @@ class NaoAudioInterface(ALModule, NaoqiNode):
             rospy.logerror("Could not get a proxy to ALAudioSourceLocalization on %s:%d", self.pip, self.pport)
             exit(1)
         #~ ALAudioSourceLocalization parameter trimming
-        self.audioSourceLocalizationProxy.setParameter("EnergyComputation", 1)
+        self.audioSourceLocalizationProxy.setParameter("EnergyComputation", True)
         self.audioSourceLocalizationProxy.setParameter("Sensibility", 0.8)
 
     def playFileSrv(self, req):


### PR DESCRIPTION
When I ran 
`roslaunch nao_audio nao_audio.launch`
this error occurred:

```
RuntimeError: ALAudioSourceLocalization::setParameter
　　ALAudioSourceLocalization::setParameter
EnergyComputation expects a boolean value.
[INFO] [WallTime: 1416826035.142637] Stopping nao_audio_interface
[INFO] [WallTime: 1416826035.142780] nao_audio_interface stopped
```

So I fixed "1" to "True" in 
`self.audioSourceLocalizationProxy.setParameter("EnergyComputation", 1)`.
