### PR TITLE
[nao_interaction_msgs & nao_audio] add Get/SetAudioMasterVolume.srv

### DIFF
--- a/nao_audio/nodes/nao_audio.py
+++ b/nao_audio/nodes/nao_audio.py
@@ -54,7 +54,8 @@ from nao_interaction_msgs.msg import (
     AudioSourceLocalization)
 
 from nao_interaction_msgs.srv import (
-    AudioMasterVolume,
+    SetAudioMasterVolumeResponse,
+    SetAudioMasterVolume,
     AudioRecorder,
     AudioPlayback)
 
@@ -75,7 +76,7 @@ class NaoAudioInterface(ALModule, NaoqiNode):
         
         #~ ROS initializations
         self.playFileSrv = rospy.Service("nao_audio/play_file", AudioPlayback, self.playFileSrv )        
-        self.masterVolumeSrv = rospy.Service("nao_audio/master_volume", AudioMasterVolume, self.handleAudioMasterVolumeSrv)
+        self.masterVolumeSrv = rospy.Service("nao_audio/master_volume", SetAudioMasterVolume, self.handleAudioMasterVolumeSrv)
         self.enableRecordSrv = rospy.Service("nao_audio/record", AudioRecorder, self.handleRecorderSrv)
         
         self.audioSourceLocalizationPub = rospy.Publisher("nao_audio/audio_source_localization", AudioSourceLocalization)
@@ -134,11 +135,11 @@ class NaoAudioInterface(ALModule, NaoqiNode):
         
     def handleAudioMasterVolumeSrv(self, req):
         if (req.master_volume.data < 0) or (req.master_volume.data > 100):
-            return EmptyResponse
-        
+            return
+
         self.audioDeviceProxy.setOutputVolume(req.master_volume.data)
-        return EmptyResponse
-    
+        return SetAudioMasterVolumeResponse()
+
     def handleRecorderSrv(self, req):
         
         file_path = req.file_path.data

--- a/nao_interaction_msgs/CMakeLists.txt
+++ b/nao_interaction_msgs/CMakeLists.txt
@@ -35,7 +35,8 @@ add_service_files(DIRECTORY srv
     LearnFace.srv
     #~ nao_audio
     AudioRecorder.srv
-    AudioMasterVolume.srv
+    SetAudioMasterVolume.srv
+    GetAudioMasterVolume.srv
     AudioPlayback.srv
 )
 

--- a/nao_interaction_msgs/srv/GetAudioMasterVolume.srv
+++ b/nao_interaction_msgs/srv/GetAudioMasterVolume.srv
@@ -1,0 +1,5 @@
+# Service for getting the master volume of NAO and Pepper
+
+---
+# Output must be between 0 and 100
+std_msgs/Int32 master_volume

--- a/nao_interaction_msgs/srv/SetAudioMasterVolume.srv
+++ b/nao_interaction_msgs/srv/SetAudioMasterVolume.srv
@@ -1,4 +1,4 @@
-# Service for setting the master volume of NAO
+# Service for setting the master volume of NAO and Pepper
 # Input must be between 0 and 100
 
 std_msgs/Int32 master_volume


### PR DESCRIPTION
- renamed  ```AudioMasterVolume.srv``` to ```SetAudioMasterVolume.srv```.
- added ```GetAudioMasterVolume.srv```.
- modified ```nao_audio.py``` so that it works with new srv file and correct return value

I also want to use these srv files in naoqi_driver package (~https://github.com/ros-naoqi/naoqi_driver/pull/89~ https://github.com/ros-naoqi/naoqi_driver/pull/97)

I also found several services of ```nao_audio.py``` don't have correct return values, but I didn't fix them in this pull-request. I will fix them in a next pull-request. 
  